### PR TITLE
link tag without rel

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function (html, options) {
 
     $('link').each(function (index, element) {
         var $el = $(element);
-        if ($el.attr('rel').toLowerCase() === 'stylesheet') {
+        if ($el.attr('rel') && $el.attr('rel').toLowerCase() === 'stylesheet') {
             if (options.applyLinkTags) {
                 results.hrefs.push($el.attr('href'));
             }


### PR DESCRIPTION
Hi, how are you?

The issue :

``` javscript
if ($el.attr('rel').toLowerCase() === 'stylesheet') {
                           ^
TypeError: Cannot read property 'toLowerCase' of undefined
```

Why this is happend ? 
Because not every `<link>` tag contains a rel atribute.

Example:

``` html
<div itemscope itemtype="http://schema.org/EmailMessage">
    <meta itemprop="description" content="Watch the 'Avengers' movie online"/>
    <div itemprop="action" itemscope itemtype="http://schema.org/ViewAction">
        <link itemprop="url" href="https://watch-movies.com/watch?movieId=abc123"/>
        <meta itemprop="name" content="Watch movie"/>
    </div>
    <div itemprop="publisher" itemscope itemtype="http://schema.org/Organization">
        <meta itemprop="name" content="Google Play"/>
        <link itemprop="url" href="https://play.google.com"/>
        <link itemprop="url/googlePlus" ref="https://plus.google.com/106886664866983861036"/>
    </div>
</div>
```

I fixed.
Hope you like it. 
