### PR TITLE
Added typecasting to __html.replace

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function (html, options) {
             Object.keys(blocks).forEach(function (key) {
                 var re = new RegExp(blocks[key].start + '([\\S\\s]*?)' + blocks[key].end, 'g');
 
-                __html = __html.replace(re, function (match) {
+                __html = String(__html).replace(re, function (match) {
                     codeBlockLookup.push(match);
                     return 'EXCS_CODE_BLOCK_' + (codeBlockLookup.length - 1) + '_';
                 });


### PR DESCRIPTION
We have been using Inky through Foundation to build out HTML emails. This update seemed to break that build process, but adding this seemed to fix the issue.