### PR TITLE
convert value to string before calling replace()

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = function (html, options) {
         },
         codeBlockLookup = [],
         encodeCodeBlocks = function (_html) {
-            var __html = _html,
+            var __html = String(_html),
                 blocks = extend(codeBlocks, options.codeBlocks);
 
             Object.keys(blocks).forEach(function (key) {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "mocha",
     "coverage": "nyc npm test && nyc report",
+    "postcoverage": "node ./setup/process-coverage-report.js",
     "coveralls": "nyc npm test && nyc report --reporter=text-lcov | coveralls"
   },
   "repository": {
@@ -21,6 +22,16 @@
     "url": "https://github.com/jonkemp/list-stylesheets/issues"
   },
   "homepage": "https://github.com/jonkemp/list-stylesheets",
+  "nyc": {
+    "reporter": [
+      "html"
+    ],
+    "report-dir": "./.test_output/coverage",
+    "cache": true,
+    "all": true,
+    "sourceMap": true,
+    "instrument": true
+  },
   "dependencies": {
     "cheerio": "^0.22.0",
     "extend": "^3.0.1",
@@ -32,6 +43,7 @@
     "gulp-eslint": "^4.0.2",
     "gulp-mocha": "^5.0.0",
     "gulp-util": "^3.0.8",
+    "inline-css": "^2.4.0",
     "mocha": "^5.0.1",
     "nyc": "^11.4.1",
     "should": "^13.2.1"

--- a/setup/process-coverage-report.js
+++ b/setup/process-coverage-report.js
@@ -1,0 +1,40 @@
+let fs = require("fs"),
+    path = require("path"),
+    inline = require("inline-css");
+
+const CODE_COVERAGE_DIRECTORY = "./../.test_output/coverage";
+
+const read = (dir) =>
+    fs.readdirSync(dir)
+        .reduce((files, file) =>
+                fs.statSync(path.join(dir, file)).isDirectory() ?
+                    files.concat(read(path.join(dir, file))) :
+                    files.concat(path.join(dir, file)),
+            []);
+
+const absPath = path.join(__dirname, CODE_COVERAGE_DIRECTORY);
+
+let reports = read(absPath).filter((report)=> {
+    return report.endsWith(".html");
+});
+
+reports.forEach((report)=> {
+    let options = {
+        url: "file://" + report,
+        extraCss: ".pad1 { padding: 0; }"
+    };
+
+    fs.readFile(report, (err, data) => {
+        inline(data, options)
+            .then((html) => {
+                fs.writeFile(report, html, (err) => {
+                    if (err) {
+                        throw err;
+                    }
+                });
+            })
+            .catch((err) => {
+                console.log(err);
+            });
+    });
+});


### PR DESCRIPTION
Explicitly convert value to string to fix error "TypeError: __html.replace is not a function"

I don't know precisely what in my project is causing the error, but converting to string first fixes it. I'm using inline-css... maybe it's passing the value as null or undefined?